### PR TITLE
Add --version flag to archive subcommand.

### DIFF
--- a/src/leiningen/immutant/archive.clj
+++ b/src/leiningen/immutant/archive.clj
@@ -9,7 +9,8 @@
 (def archive-options
   (concat
    [["-e" "--exclude-dependencies" :flag true]
-    ["-n" "--name"]]
+    ["-n" "--name"]
+    ["-v" "--version" :flag true]]
    c/descriptor-options))
 
 (defn dependency-overrides [project]
@@ -48,9 +49,10 @@
 
 Creates an Immutant archive (suffixed with '.ima') in target/.  By
 default, the archive file will be named after the project name in
-project.clj. This can be overridden via the --name (or -n)
-option. This archive can be deployed in lieu of a descriptor pointing
-to the app directory.
+project.clj. This can be overridden via the --name (or -n) option. If
+the --version (or -v) flag is specified, the project version will be
+appended to the name. This archive can be deployed in lieu of a
+descriptor pointing to the app directory.
 
 Any profiles that are active (via with-profile) will be captured and
 applied when the app is deployed.


### PR DESCRIPTION
This adds a --version flag to the archive subcommand. When set, the project version will be included in the Immutant archive name. Needs a supporting change to deploy-tools, sent in a separate pull request.

Rationale: for deployment, we push the .ima files up to artifactory using the lein-package plugin. This requires the project version in the .ima filename. Happy to consider other approaches if this pull request is not the way to go.
