### PR TITLE
Added --to-file, --format and --output-file options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.immutant/deploy-tools                   "0.14.2"]
                  [org.immutant/immutant-dependency-exclusions "0.1.0"]
                  [org.clojure/data.json                       "0.2.1"]
-                 [org.immutant/fntest                         "0.5.3"]]
+                 [org.immutant/fntest                         "0.5.5-SNAPSHOT"]]
   :profiles {:dev
              {:dependencies [[lein-midje "2.0.3"]
                              [leinjacker "0.4.2"]

--- a/src/leiningen/immutant/test.clj
+++ b/src/leiningen/immutant/test.clj
@@ -11,8 +11,7 @@
   [["--offset" :parse-fn read-string]
    ["--log-level"]
    ["-f" "--format"] ;; format can be tap or junit
-   ["-t" "--to-file" :flag true] ;; has to be set to write to an output file
-   ["-o" "--output-file" :default "testresults.xml"]])
+   ["-o" "--output-file"]])
 
 (defn test
   "Runs a project's tests inside the current Immutant

--- a/src/leiningen/immutant/test.clj
+++ b/src/leiningen/immutant/test.clj
@@ -9,7 +9,10 @@
 
 (def test-options
   [["--offset" :parse-fn read-string]
-   ["--log-level"]])
+   ["--log-level"]
+   ["-f" "--format"] ;; format can be tap or junit
+   ["-t" "--to-file" :flag true] ;; has to be set to write to an output file
+   ["-o" "--output-file" :default "testresults.xml"]])
 
 (defn test
   "Runs a project's tests inside the current Immutant


### PR DESCRIPTION
--format can be "junit", "tap" or empty
--to-file has to be set to write to an output file
--output-file path to the output file [default: testresults.xml]
